### PR TITLE
Corrects virtualenv version check failure in circleci

### DIFF
--- a/{{cookiecutter.project_dashed}}-src/.circleci/config.yml
+++ b/{{cookiecutter.project_dashed}}-src/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
                 command: |
                     {{cookiecutter.python_executable}} --version
                     {{cookiecutter.python_executable}} -m pip --version
-                    {{cookiecutter.python_executable}} -m venv --version
+                    {{cookiecutter.python_executable}} -m virtualenv --version
                     tox --version
 
             - run:


### PR DESCRIPTION
Fixes #12.

It doesn't look like the command `python -m venv --version` exists. Changing it to `python -m virtualenv --version` works. Is that what you had in mind?