### PR TITLE
Keg auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2
 jobs:
     build:
         docker:
-            - image: circleci/python:3.5.3
+            - image: level12/python-test-multi
             - image: postgres:9.6
               environment:
                   POSTGRES_USER: postgres
                   POSTGRES_PASSWORD: password
         steps:
             - checkout
-            - run: sudo pip install tox cookiecutter wheelhouse
+            - run: sudo python3.5 -m pip install tox cookiecutter wheelhouse
             - run:
                 name: version checks
                 command: |
@@ -26,7 +26,7 @@ jobs:
                 working_directory: /tmp/keg-app-ci-src
                 command: |
                     wheelhouse build
-                    python3 -m venv keg-app-ci
+                    virtualenv --python python3.5 keg-app-ci
                     . keg-app-ci/bin/activate
                     wheelhouse install -- -r requirements/dev-env.txt
 

--- a/{{cookiecutter.project_dashed}}-src/.circleci/config.yml
+++ b/{{cookiecutter.project_dashed}}-src/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
     build:
         docker:
-            - image: circleci/python:{{cookiecutter.python_version}}
+            - image: level12/python-test-multi
             - image: postgres:9.6
               environment:
                   POSTGRES_USER: postgres

--- a/{{cookiecutter.project_dashed}}-src/alembic/README
+++ b/{{cookiecutter.project_dashed}}-src/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/{{cookiecutter.project_dashed}}-src/alembic/env.py
+++ b/{{cookiecutter.project_dashed}}-src/alembic/env.py
@@ -1,0 +1,64 @@
+from alembic import context
+from keg.db import db
+
+from {{cookiecutter.project_namespace}}.app import {{cookiecutter.project_class}}
+
+
+app = {{cookiecutter.project_class}}().init()
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = db.metadata
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = db.get_engines(app)[0][1]
+
+    print("Operating on database at: {}".format(connectable.url))
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/{{cookiecutter.project_dashed}}-src/alembic/script.py.mako
+++ b/{{cookiecutter.project_dashed}}-src/alembic/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/{{cookiecutter.project_dashed}}-src/requirements/include/common.txt
+++ b/{{cookiecutter.project_dashed}}-src/requirements/include/common.txt
@@ -1,6 +1,8 @@
+alembic
 flake8
+flask-bootstrap
 flask-webtest
-KegElements
+git+https://github.com/level12/keg-auth.git#egg=KegAuth
 mock
 psycopg2
 pyquery

--- a/{{cookiecutter.project_dashed}}-src/tox.ini
+++ b/{{cookiecutter.project_dashed}}-src/tox.ini
@@ -8,7 +8,6 @@ setenv =
     PIP_NO_INDEX=true
     PIP_FIND_LINKS=requirements/wheelhouse
 
-
 passenv =
     # Pass this through for testing with docker-run-tests locally.
     {{ cookiecutter.db_url_env_name }}
@@ -29,7 +28,8 @@ commands =
     pip install -r requirements/deployed-env.txt
     py.test \
         # turn warnings into errors
-        -Werror \
+        # Can't use the next line due to https://github.com/kvesteri/sqlalchemy-utils/issues/268
+        # -Werror \
         # feed a blank file so that a user's default pytest.ini doesn't get used
         -c .ci/pytest.ini \
         -ra \

--- a/{{cookiecutter.project_dashed}}-src/wheelhouse.ini
+++ b/{{cookiecutter.project_dashed}}-src/wheelhouse.ini
@@ -1,3 +1,6 @@
 [wheelhouse]
 requirement_files =
     wheelhouse-build.txt
+
+
+pip_bins = pip3.5

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}-config.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}-config.py
@@ -3,12 +3,17 @@ DEFAULT_PROFILE = 'DevProfile'
 
 
 class DevProfile(object):
-    # secret key for Flask
-    SECRET_KEY = ''
+    # Secret key for Flask -- CHANGE THIS!
+    SECRET_KEY = 'abc123'
 
+    # TODO: are these needed?  If so, add comment for where they are used.
     DEVELOPER_NAME = '{{cookiecutter.developer_name}}'
     DEVELOPER_EMAIL = '{{cookiecutter.developer_email}}'
-    KEG_EMAIL_OVERRIDE_TO = DEVELOPER_EMAIL
+
+    MAIL_DEFAULT_SENDER = '{{cookiecutter.developer_email}}'
+
+    # Needed by at least KegAuth for sending emails from the command line
+    SERVER_NAME = 'localhost:5000'
 
 
 class TestProfile(object):

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/app.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/app.py
@@ -1,11 +1,9 @@
 from flask_bootstrap import Bootstrap
-import flask_login
 from flask_mail import Mail
 from keg import Keg
 import keg_auth
 from flask_wtf.csrf import CSRFProtect
 
-import {{cookiecutter.project_namespace}}.model.entities as ents
 from {{cookiecutter.project_namespace}}.views import blueprints
 
 csrf = CSRFProtect()

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/app.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/app.py
@@ -1,9 +1,51 @@
+from flask_bootstrap import Bootstrap
+import flask_login
+from flask_mail import Mail
 from keg import Keg
+import keg_auth
+from flask_wtf.csrf import CSRFProtect
 
-from {{cookiecutter.project_namespace}}.views import public
+import {{cookiecutter.project_namespace}}.model.entities as ents
+from {{cookiecutter.project_namespace}}.views import blueprints
+
+csrf = CSRFProtect()
+mail_ext = Mail()
+
+
+class AuthManager(keg_auth.AuthManager):
+
+    def create_user_cli(self, email, extra_args):
+        """ A thin layer between the cli and `create_user()` to transform the cli args
+            into what the User entity expects for fields.
+
+            For example, if you had a required `name` field on your User entity, then you could do
+            something like::
+
+                $ yourkegapp auth create-user john.smith@example.com "John Smith"
+
+            Then this method would get overriden in a sub-class like:
+
+                def create_user_cli(self, email, extra_args):
+                    user_kwargs = dict(email=email, name=extra_args[0])
+                    return self.create_user(user_kwargs)
+        """
+        # Our user model takes a required name field
+        assert len(extra_args) == 1
+        user_kwargs = dict(email=email, name=extra_args[0])
+        return self.create_user(user_kwargs)
+
+
+_endpoints = {'after-login': 'public.home'}
+auth_manager = AuthManager(mail_ext, endpoints=_endpoints)
 
 
 class {{cookiecutter.project_class}}(Keg):
     import_name = '{{cookiecutter.project_namespace}}'
-    use_blueprints = [public]
+    use_blueprints = blueprints
     db_enabled = True
+
+    def on_init_complete(self):
+        auth_manager.init_app(self)
+        csrf.init_app(self)
+        mail_ext.init_app(self)
+        Bootstrap(self)

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/cli.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/cli.py
@@ -8,16 +8,16 @@ log = logging.getLogger(__name__)
 
 
 def cli_entry():
-    {{cookiecutter.project_class}}.cli_run()
+    {{cookiecutter.project_class}}.cli.main()
 
 
-@{{cookiecutter.project_class}}.command('hello', short_help='Example command: say hello.')
+@{{cookiecutter.project_class}}.cli.command('hello', short_help='Example command: say hello.')
 @click.option('--name', default='World', help='The person to greet.')
 def hello_world(name):
     click.echo('Hello {} from {{cookiecutter.project_name}}!'.format(name))
 
 
-@{{cookiecutter.project_class}}.command('log', short_help='log some messages')
+@{{cookiecutter.project_class}}.cli.command('log', short_help='log some messages')
 def logcmd():
     log.info('info log message')
     log.warning('warning log message')

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/config.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/config.py
@@ -8,9 +8,23 @@ class DefaultProfile(object):
     # commands for help.
     KEG_KEYRING_ENABLE = True
 
+    # Used in at least KegAuth email templates
+    SITE_NAME = '{{cookiecutter.project_name}}'
+    # Used in at least KegAuth email subject lines
+    SITE_ABBR = '{{cookiecutter.project_name}}'
+
+    MAIL_DEFAULT_SENDER = '{{cookiecutter.developer_email}}'
+
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+
 
 class TestProfile(object):
-    KEG_KEYRING_ENABLE = False
     # These settings reflect what is needed in CI.  For local development, use
     # {{cookiecutter.project_namespace}}-config.py to override.
     SQLALCHEMY_DATABASE_URI = 'postgresql://postgres:password@localhost/postgres'
+
+    # Make tests faster
+    PASSLIB_CRYPTCONTEXT_KWARGS = dict(schemes=['plaintext'])
+
+    # silence warnings
+    KEG_KEYRING_ENABLE = False

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/model/entities.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/model/entities.py
@@ -2,6 +2,7 @@ import logging
 
 from keg.db import db
 from keg_elements.db.mixins import DefaultColsMixin, MethodsMixin
+from keg_auth import UserMixin
 import sqlalchemy as sa
 import sqlalchemy.orm as saorm
 from sqlalchemy_utils import ArrowType, EmailType
@@ -47,3 +48,10 @@ class Comment(db.Model, EntityMixin):
         if 'blog' not in kwargs and 'blog_id' not in kwargs:
             kwargs['blog'] = Blog.testing_create(_commit=False)
         return super().testing_create(**kwargs)
+
+
+class User(db.Model, UserMixin, EntityMixin):
+    """ Make sure EntityMixin is after UserMixin or testing_create() is wrong.  """
+    __tablename__ = 'users'
+
+    name = sa.Column(sa.Unicode(250), nullable=False)

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/templates/base-page.html
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/templates/base-page.html
@@ -1,0 +1,21 @@
+{% raw -%}
+{% import "bootstrap/utils.html" as utils %}
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container" id="flash-messages">
+    {%- with messages = get_flashed_messages(with_categories=True) %}
+    {%- if messages %}
+      <div class="row">
+        <div class="col-md-12">
+          {{utils.flashed_messages(messages)}}
+        </div>
+      </div>
+    {%- endif %}
+    {%- endwith %}
+</div>
+<div class="container" id="page-content">
+    {% block page_content %}{% endblock %}
+</div>
+{% endblock %}
+{% endraw %}

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/templates/base.html
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/templates/base.html
@@ -1,0 +1,9 @@
+{% raw %}{% extends "bootstrap/base.html" %}
+{% block title %}{% endraw %}
+{{cookiecutter.project_name}}
+{% raw %}{% endblock %}{% endraw %}
+
+{% raw %}{% block content %}{% endraw %}
+  <h1>Hello World from {{cookiecutter.project_name}}</h1>
+{% raw %}{% endblock %}{% endraw %}
+

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/templates/public/hello.html
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/templates/public/hello.html
@@ -1,0 +1,9 @@
+{% raw -%}
+{% extends 'base-page.html' %}
+
+{% block title %} Hello {{name}}! | {{ super() }}{% endblock %}
+
+{% block page_content %}
+<h1>Hello {{name}}!</h1>
+{% endblock %}
+{% endraw %}

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_auth.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_auth.py
@@ -1,0 +1,8 @@
+from keg_auth.testing import AuthTests
+
+from {{cookiecutter.project_namespace}}.model import entities as ents
+
+
+class TestAuthIntegration(AuthTests):
+    user_ent = ents.User
+    protected_url = '/protected-example'

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_cli.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_cli.py
@@ -1,6 +1,5 @@
 from keg.testing import CLIBase
 
-from {{cookiecutter.project_namespace}}.app import {{cookiecutter.project_class}}
 from {{cookiecutter.project_namespace}}.model import entities as ents
 
 
@@ -17,4 +16,5 @@ class TestCLI(CLIBase):
         assert 'Hello Foo from {{cookiecutter.project_name}}!\n' == result.output
 
     def test_add_user(self):
-        result = self.invoke('auth', 'create-user', 'foo@bar.com', 'Foo Bar')
+        self.invoke('auth', 'create-user', 'foo@bar.com', 'Foo Bar')
+        assert ents.User.query.count() == 1

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_cli.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_cli.py
@@ -1,15 +1,20 @@
 from keg.testing import CLIBase
 
 from {{cookiecutter.project_namespace}}.app import {{cookiecutter.project_class}}
+from {{cookiecutter.project_namespace}}.model import entities as ents
 
 
 class TestCLI(CLIBase):
-    app_cls = {{cookiecutter.project_class}}
-    cmd_name = 'hello'
+
+    def setup(self):
+        ents.User.delete_cascaded()
 
     def test_hello(self):
-        result = self.invoke()
+        result = self.invoke('hello')
         assert 'Hello World from {{cookiecutter.project_name}}!\n' == result.output
 
-        result = self.invoke('--name', 'Foo')
+        result = self.invoke('hello', '--name', 'Foo')
         assert 'Hello Foo from {{cookiecutter.project_name}}!\n' == result.output
+
+    def test_add_user(self):
+        result = self.invoke('auth', 'create-user', 'foo@bar.com', 'Foo Bar')

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_model.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_model.py
@@ -30,3 +30,17 @@ class TestComment(ModelBase):
         with pytest.raises(IntegrityError) as excinfo:
             ents.Comment.testing_create(blog=blog, author_name='foo')
         assert 'violates unique constraint "uc_comments_unique_author"' in str(excinfo.value)
+
+
+class TestUser(ModelBase):
+    orm_cls = ents.User
+    constraint_tests = [
+        # column name, is FK?, is required?
+        ('is_verified', False, True),
+        ('is_enabled', False, True),
+        ('email', False, True),
+        ('password', False, True),
+        ('token', False, False),
+        ('token_created_utc', False, False),
+        ('name', False, True),
+    ]

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_views.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_views.py
@@ -19,3 +19,10 @@ class TestPublic(ViewBase):
     def test_ping(self):
         resp = self.ta.get('/ping')
         assert resp.text == '{{cookiecutter.project_namespace}} ok'
+
+    def test_hello(self):
+        resp = self.ta.get('/hello')
+        assert 'Hello World!' in resp
+
+        resp = self.ta.get('/hello/foo')
+        assert 'Hello foo!' in resp

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/views/__init__.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/views/__init__.py
@@ -1,0 +1,4 @@
+from .auth import auth_bp
+from .public import public_bp
+
+blueprints = (public_bp, auth_bp)

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/views/auth.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/views/auth.py
@@ -1,0 +1,19 @@
+import logging
+
+from blazeutils.strings import case_cw2dash
+import flask
+from keg_auth import AuthenticatedView, make_blueprint
+
+import {{cookiecutter.project_namespace}}.model.entities as ents
+
+log = logging.getLogger(__name__)
+
+auth_bp = make_blueprint(__name__)
+
+
+class ProtectedExample(AuthenticatedView):
+    """ This is just an example of a view that will require being logged in to view it. """
+    blueprint = auth_bp
+
+    def get(self):
+        return 'hi'

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/views/auth.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/views/auth.py
@@ -1,10 +1,6 @@
 import logging
 
-from blazeutils.strings import case_cw2dash
-import flask
 from keg_auth import AuthenticatedView, make_blueprint
-
-import {{cookiecutter.project_namespace}}.model.entities as ents
 
 log = logging.getLogger(__name__)
 

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/views/public.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/views/public.py
@@ -1,0 +1,20 @@
+import logging
+
+import flask
+from keg.web import BaseView, rule
+
+public_bp = flask.Blueprint('public', __name__,)
+log = logging.getLogger(__name__)
+
+
+@public_bp.route('/')
+def home():
+    return 'Hello World from {{cookiecutter.project_name}}!'
+
+
+class Hello(BaseView):
+    blueprint = public_bp
+    rule('<name>')
+
+    def get(self, name='World'):
+        self.assign('name', name)


### PR DESCRIPTION
integrate KegAuth, Flask-Bootstrap, and Alembic migration basics

- fixes #6 - using Keg Auth instead of Keg Login
- fixes #10 - uses Keg 0.6, which fixes the app & CLI init
- fixes #11 - email support added for Keg Auth