### PR TITLE
56 celery startup fix

### DIFF
--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/celery/app.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/celery/app.py
@@ -41,4 +41,4 @@ celery_app = Celery(
 )
 
 # Quickly fail if RabbitMQ can't be reached so tests/scripts don't hang.
-celery_app.conf['broker_transport_options'] = {"max_retries": 1,}
+celery_app.conf['broker_transport_options'] = {"max_retries": 1}

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/celery/app.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/celery/app.py
@@ -39,3 +39,6 @@ celery_app = Celery(
     '{{cookiecutter.project_namespace}}',
     include=['{{cookiecutter.project_namespace}}.celery.tasks']
 )
+
+# Quickly fail if RabbitMQ can't be reached so tests/scripts don't hang.
+celery_app.conf['broker_transport_options'] = {"max_retries": 1,}

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/celery/testing.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/celery/testing.py
@@ -43,7 +43,12 @@ class TaskTracker:
                 assert ents.DbRecord.count == 1
     """
     def __init__(self):
-        self.reset()
+        # Don't call reset here, even though the variable assignment is the same.  A reset
+        # in the constructor causes the connection to RabbitMQ to be established before
+        # it has application-level configuration applied, which means we aren't connecting to the
+        # RabbitMQ server we think we are.
+        self.task_results = {}
+        self.slept = 0
 
     def reset(self):
         self.task_results = {}

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/libs/mail.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/libs/mail.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 
 from blazeutils.strings import normalizews
-import CommonMark as commonmark
+import commonmark
 import flask
 import flask_mail
 

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_model.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_model.py
@@ -47,4 +47,5 @@ class TestUser(EntityBase):
         ColumnCheck('password', required=False),
         ColumnCheck('name'),
         ColumnCheck('settings', required=False),
+        ColumnCheck('last_login_utc', required=False),
     ]

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_views.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/tests/test_views.py
@@ -1,5 +1,5 @@
 import flask
-from flask.ext import webtest
+import flask_webtest as webtest
 from keg_auth.testing import ViewTestBase as AuthViewBase, AuthTestApp
 
 from {{cookiecutter.project_namespace}}.model import entities


### PR DESCRIPTION
fixes #56 

Also:
- updates `commonmark` import following the 3rd-party breaking update
- adds `last_login_utc` test to make model tests happy after keg-auth change
- changes `flask_webtest` import due to deprecation warning