### PR TITLE
fix alembic version backup

### DIFF
--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/conftest.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/conftest.py
@@ -10,6 +10,8 @@ import {{cookiecutter.project_namespace}}.libs.db as libs_db
 # You can uncomment this if you end up with asserts in libraries outside tests.
 # pytest.register_assert_rewrite('{{cookiecutter.project_namespace}}.libs.testing')
 
+pytest_plugins = ('celery.contrib.pytest',)
+
 
 def pytest_configure(config):
     {{cookiecutter.project_class}}.testing_prep(

--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/libs/db.py
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/libs/db.py
@@ -286,7 +286,7 @@ class PostgresBackup(PostgresBase):
 
             public_tables = self.get_table_list_from_db('public')
             if 'alembic_version' in public_tables:
-                self.pg_dump('alembic.sql', '-t', 'alembic_version')
+                self.pg_dump('-t', 'alembic_version', back_type='alembic.sql')
 
         if backup_type in ('both', 'full'):
             self.pg_dump('--format', 'custom', '--blobs', back_type='full.bak')


### PR DESCRIPTION
The alembic change is to avoid the backup throwing an error on line 276.
See https://level12.atlassian.net/l/c/RWy5x0SF for the celery error change. 