### PR TITLE
Enable setting environment variables from file

### DIFF
--- a/{{cookiecutter.project_dashed}}-src/.flaskenv-example
+++ b/{{cookiecutter.project_dashed}}-src/.flaskenv-example
@@ -1,0 +1,1 @@
+FLASK_ENV=development

--- a/{{cookiecutter.project_dashed}}-src/.gitignore
+++ b/{{cookiecutter.project_dashed}}-src/.gitignore
@@ -8,6 +8,9 @@
 /htmlcov
 .pytest_cache
 
+# .env file for Flask development server
+.flaskenv
+
 # Visual Studio Code clutter
 .vscode
 tags

--- a/{{cookiecutter.project_dashed}}-src/readme.rst
+++ b/{{cookiecutter.project_dashed}}-src/readme.rst
@@ -104,6 +104,9 @@ Quickstart
 #. Copy the file `{{cookiecutter.project_namespace}}-config-example.py` at the root of this project to
    `{{cookiecutter.project_namespace}}-config.py`. Adjust settings as needed for your local dev environment.
 
+#. Copy the file `.flaskenv-example` at the root of this project to `.flaskenv`. Adjust settings as
+   needed for your local dev environment.
+
 #. Run `tox` and verify the tests pass.  Read the tox file to learn how this project sets up
    dependencies and runs tests.
 

--- a/{{cookiecutter.project_dashed}}-src/requirements/common.in
+++ b/{{cookiecutter.project_dashed}}-src/requirements/common.in
@@ -10,6 +10,7 @@ psycopg2-binary
 pyquery
 pytest
 pytest-cov
+python-dotenv
 requests
 responses
 sentry_sdk


### PR DESCRIPTION
- Add python-dotenv as a dependency
  - Flask will read .flaskenv or .env by default when python-dotenv is
    installed, when running the Flask dev server
- Add example .flaskenv file
- Add instructions to copy .flaskenv file
- Depends on level12/keg#152

Fixes GH-101
