### PR TITLE
Fix nav-item style being set globally

### DIFF
--- a/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/static/css/app.css
+++ b/{{cookiecutter.project_dashed}}-src/{{cookiecutter.project_namespace}}/static/css/app.css
@@ -11,7 +11,7 @@
 }
 
 .navbar-nav > .nav-item.nav-current,
-.nav-item:hover {
+.navbar-nav > .nav-item:hover {
     background-color: #ddd;
 }
 


### PR DESCRIPTION
- Prevent hover state for all .nav-item elements from being set
- Scope rule to .navbar-nav