### PR TITLE
Cronitor environments

### DIFF
--- a/{{cookiecutter.src_dirname}}/ansible/deploy.yaml
+++ b/{{cookiecutter.src_dirname}}/ansible/deploy.yaml
@@ -47,6 +47,5 @@
         name: run celery ping/log command every minute
         minute: "*"
         job: "{{ sentry_cron_cmd }} --quiet celery ping-alive"
-      when: app_celery_alive_url is defined
       tags: cron
 {% endraw %}

--- a/{{cookiecutter.src_dirname}}/ansible/files/{{cookiecutter.project_pymod}}-config.py
+++ b/{{cookiecutter.src_dirname}}/ansible/files/{{cookiecutter.project_pymod}}-config.py
@@ -24,7 +24,6 @@ class DeployedProfile(object):
     MAIL_DEFAULT_SENDER = 'devteam@level12.io'
     MAIL_DEBUG = False
 
-    CELERY_ALIVE_URL = '{{ app_celery_alive_url }}'
     CELERY = celery_config(broker_url='amqp://guest@localhost:12672//')
 
     # Needed by at least KegAuth for sending emails from the command line
@@ -32,4 +31,6 @@ class DeployedProfile(object):
     # This is important so that generated auth related URLS are secure.  We have an SSL redirect
     # but by the time that would fire, the key would have already been sent in the URL.
     PREFERRED_URL_SCHEME = 'https'
+
+    CRONITOR_ENV = '{{ "production" if app_environment == "prod" else "beta" }}'
 {% endraw %}

--- a/{{cookiecutter.src_dirname}}/ansible/group_vars/all
+++ b/{{cookiecutter.src_dirname}}/ansible/group_vars/all
@@ -31,7 +31,6 @@ app_rabbitmq_user: "{{project_ident_env}}"
 
 app_celery_dir: '{{ project_home_dpath }}/celery'
 app_celery_pid_fpath: /tmp/{{ project_ident }}_celery.pid
-app_celery_alive_url: https://cronitor.link/{{app_celery_alive_key}}/complete
 
 nginx_vhost_name: "{{project_ident}}"
 nginx_vhost_enable_static_route: false

--- a/{{cookiecutter.src_dirname}}/ansible/group_vars/beta
+++ b/{{cookiecutter.src_dirname}}/ansible/group_vars/beta
@@ -1,7 +1,5 @@
 app_environment: beta
 
-app_celery_alive_key: '{{ cookiecutter.celery_alive_key_beta }}'
-
 {% raw %}
 app_flask_secret_key: "{{ app_flask_secret_key_beta }}"
 app_db_pass: "{{ app_db_pass_beta }}"

--- a/{{cookiecutter.src_dirname}}/ansible/group_vars/prod
+++ b/{{cookiecutter.src_dirname}}/ansible/group_vars/prod
@@ -1,7 +1,5 @@
 app_environment: prod
 
-app_celery_alive_key: '{{ cookiecutter.celery_alive_key_prod }}'
-
 {% raw %}
 app_flask_secret_key: "{{ app_flask_secret_key_prod }}"
 app_db_pass: "{{ app_db_pass_prod }}"

--- a/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}-config-example.py
+++ b/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}-config-example.py
@@ -27,6 +27,8 @@ class DevProfile:
 
     CELERY = celery_config(broker_url='amqp://guest@localhost:12672//')
 
+    CRONITOR_ENV = 'developer'
+
 
 class TestProfile:
     SQLALCHEMY_DATABASE_URI = '{{cookiecutter.sa_db_uri_prefix.rstrip("/")}}/{{cookiecutter.project_dashed}}-tests'

--- a/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}/celery/tasks.py
+++ b/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}/celery/tasks.py
@@ -1,10 +1,48 @@
+import contextlib
+import keg
 import logging
-
 import requests
 
 from .app import celery_app as app
 
 log = logging.getLogger(__name__)
+
+
+def cronitor_ping(config_key, endpoint, alive=True):
+    if not alive:
+        # This is to support a common pattern in our CLI commands where we may or may not want to
+        # ping cronitor based on a CLI flag. Keeps us from scattering "if" statements everywhere.
+        return
+    monitor_key = keg.current_app.config[config_key]
+    env = keg.current_app.config['CRONITOR_ENV']
+    url = f'https://cronitor.link/{monitor_key}/{endpoint}?env={env}'
+    ping_url.apply_async((url,), priority=1)
+
+
+@contextlib.contextmanager
+def cronitor_job(config_key, alive):
+    _last_endpoint = 'complete'
+
+    def last_ping(endpoint):
+        # `ok` is used to "reset" a cronitor once it's started.  It's a way to finish a cronitor run
+        # without using the "complete" endpoint.  E.g. run a job hourly that checks a mail server
+        # for incoming mail that only arrives once a day.  In this case, you'd set the cronitor
+        # up to be scheduled every hour but require it to complete once a day.  You'd set `ok`
+        # every time you run and the mail isn't there and leave the default of `complete` when
+        # you process the email once a day.
+        #
+        # `fail` used to fail the job without requiring an exception to be thrown.
+        assert endpoint in ('ok', 'fail')
+        nonlocal _last_endpoint
+        _last_endpoint = endpoint
+
+    cronitor_ping(config_key, 'run', alive)
+    try:
+        yield last_ping
+        cronitor_ping(config_key, _last_endpoint, alive)
+    except Exception:
+        cronitor_ping(config_key, 'fail', alive)
+        raise
 
 
 @app.task(bind=True, max_retries=10)

--- a/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}/cli/celery.py
+++ b/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}/cli/celery.py
@@ -1,5 +1,4 @@
 import click
-from keg import current_app
 
 from ..app import {{cookiecutter.project_class}}
 from ..celery import tasks
@@ -12,8 +11,7 @@ def celery():
 
 @celery.command()
 def ping_alive():
-    alive_url = current_app.config['CELERY_ALIVE_URL']
-    tasks.ping_url.apply_async((alive_url,), priority=1)
+    tasks.cronitor_ping('CRONITOR_CELERY_ALIVE', 'complete')
 
 
 @celery.command()

--- a/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}/config.py
+++ b/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}/config.py
@@ -36,6 +36,10 @@ class DefaultProfile(object):
         KEGAUTH_FORGOT_ATTEMPT_LOCKOUT
     ) = KEGAUTH_LOGIN_ATTEMPT_LOCKOUT = (60 * 60)
 
+    # Monitor keys
+    CRONITOR_CELERY_ALIVE = ''
+
+
 
 class TestProfile(object):
     # These settings reflect what is needed in CI.  For local development, use
@@ -53,4 +57,4 @@ class TestProfile(object):
         'broker_url': 'amqp://guest@localhost:5672//',
     }
 
-    CELERY_ALIVE_URL = 'keep-celery-alive'
+    CRONITOR_CELERY_ALIVE = 'keep-celery-alive'

--- a/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}/tests/test_views.py
+++ b/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}/tests/test_views.py
@@ -25,12 +25,18 @@ class TestPublic:
         resp = self.client.get('/ping')
         assert resp.text == '{{cookiecutter.project_pymod}} ok'
 
-    @mock_patch('{{cookiecutter.project_pymod}}.views.public.ctasks')
-    def test_health_check(self, m_ctasks):
+    @mock_patch('marsh.views.public.ctasks.cronitor_ping')
+    def test_health_check(self, m_cronitor_ping):
         # Use this for cronitor.
         resp = self.client.get('/health-check')
-        assert resp.text == '{{cookiecutter.project_pymod}} ok'
-        m_ctasks.ping_url.apply_async.assert_called_once_with(('keep-celery-alive',), priority=10)
+        assert resp.text == 'marsh ok'
+        m_cronitor_ping.assert_called_once_with('CRONITOR_CELERY_ALIVE', 'complete')
+
+    # def test_health_check(self, m_ctasks):
+    #     # Use this for cronitor.
+    #     resp = self.client.get('/health-check')
+    #     assert resp.text == '{{cookiecutter.project_pymod}} ok'
+    #     m_ctasks.ping_url.apply_async.assert_called_once_with(('keep-celery-alive',), priority=10)
 
     def test_exception(self):
         # This tests the app exception route, not Kegs.

--- a/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}/views/public.py
+++ b/{{cookiecutter.src_dirname}}/{{cookiecutter.project_pymod}}/views/public.py
@@ -29,9 +29,7 @@ class HealthCheck(BaseView):
         # something like Cronitor is hitting this URL repeatedly to monitor uptime.
         log.info('ping-db ok')
 
-        alive_url = flask.current_app.config['CELERY_ALIVE_URL']
-
-        ctasks.ping_url.apply_async((alive_url,), priority=10)
+        ctasks.cronitor_ping('CRONITOR_CELERY_ALIVE', 'complete')
 
         return '{} ok'.format(flask.current_app.name)
 


### PR DESCRIPTION
Ref #165 
Should `CRONITOR_CELERY_ALIVE` come from a variable in the playbook, or from the cookiecutter?